### PR TITLE
Added support for dependencies

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -41,6 +41,7 @@ default[:wof_pip][:data][:metafiles]      = %w(
   wof-localadmin-latest
   wof-neighbourhood-latest
   wof-region-latest
+  wof-dependency-latest
 )
 default[:wof_pip][:data][:source_url] = 'http://s3.amazonaws.com/whosonfirst.mapzen.com'
 default[:wof_pip][:data][:meta_url]   = 'https://raw.githubusercontent.com/whosonfirst/whosonfirst-data/master/meta'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -42,6 +42,8 @@ default[:wof_pip][:data][:metafiles]      = %w(
   wof-neighbourhood-latest
   wof-region-latest
   wof-dependency-latest
+  wof-macrocounty-latest
+  wof-macroregion-latest
 )
 default[:wof_pip][:data][:source_url] = 'http://s3.amazonaws.com/whosonfirst.mapzen.com'
 default[:wof_pip][:data][:meta_url]   = 'https://raw.githubusercontent.com/whosonfirst/whosonfirst-data/master/meta'


### PR DESCRIPTION
Dependency support is needed for territories as regions for US, FR, and countries so that things like `San Juan, Puerto Rico` will work.
